### PR TITLE
Petabridge.Templates v0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,6 @@ build/
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
-# FAKE
-tools/
-
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 0.2.0 January 17 2018 ####
+* [Upgrade template to .NET Standard 2.0](https://github.com/petabridge/petabridge-dotnet-new/issues/28).
+* [See the full v0.2.0 change set here](https://github.com/petabridge/petabridge-dotnet-new/milestone/1).
+
+
 #### 0.1.3 October 18 2017 ####
 * [`build.fsx` can not automatically detect TeamCity and toggle TC formatting on and off for XUnit2 test runs](https://github.com/petabridge/petabridge-dotnet-new/pull/19).
 * [Updated XUnit2 target version to 2.3.0 stable](https://github.com/petabridge/petabridge-dotnet-new/pull/20).

--- a/src/Content/Petabridge.Library/README.md
+++ b/src/Content/Petabridge.Library/README.md
@@ -33,6 +33,15 @@ All of the relevant articles you wish to write should be added to the `/docs/art
 
 All of the documentation will be statically generated and the output will be placed in the `/docs/_site/` folder. 
 
+#### Previewing Documentation
+To preview the documentation for this project, execute the following command at the root of this folder:
+
+```
+C:\> serve-docs.cmd
+```
+
+This will use the built-in `docfx.console` binary that is installed as part of the NuGet restore process from executing any of the usual `build.cmd` or `build.sh` steps to preview the fully-rendered documentation. For best results, do this immediately after calling `build.cmd buildRelease`.
+
 ### Release Notes, Version Numbers, Etc
 This project will automatically populate its release notes in all of its modules via the entries written inside [`RELEASE_NOTES.md`](RELEASE_NOTES.md) and will automatically update the versions of all assemblies and NuGet packages via the metadata included inside [`common.props`](src/common.props).
 

--- a/src/Content/Petabridge.Library/build.fsx
+++ b/src/Content/Petabridge.Library/build.fsx
@@ -271,7 +271,7 @@ Target "Nuget" DoNothing
 // all
 "BuildRelease" ==> "All"
 "RunTests" ==> "All"
-//"NBench" ==> "All"
+"NBench" ==> "All"
 "Nuget" ==> "All"
 
 RunTargetOrDefault "Help"

--- a/src/Content/Petabridge.Library/build.fsx
+++ b/src/Content/Petabridge.Library/build.fsx
@@ -129,7 +129,7 @@ Target "NBench" <| fun _ ->
     let nbenchTestPath = findToolInSubPath "NBench.Runner.exe" (toolsDir @@ "NBench.Runner*")
     printfn "Using NBench.Runner: %s" nbenchTestPath
 
-    let nbenchTestAssemblies = !! "./src/**/*Tests.Performance.csproj" 
+    let nbenchTestAssemblies = !! "./src/**/*Tests.Performance.dll" // doesn't support .NET Core at the moment
 
     let runNBench assembly =
         let includes = getBuildParam "include"

--- a/src/Content/Petabridge.Library/build.ps1
+++ b/src/Content/Petabridge.Library/build.ps1
@@ -31,9 +31,9 @@ Param(
 
 $FakeVersion = "4.61.2"
 $NBenchVersion = "1.0.1"
-$DotNetChannel = "preview";
-$DotNetVersion = "1.0.4";
-$DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1";
+$DotNetChannel = "LTS";
+$DotNetVersion = "2.0.0";
+$DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/v$DotNetVersion/scripts/obtain/dotnet-install.ps1";
 $NugetVersion = "4.1.0";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe"
 $ProtobufVersion = "3.2.0"

--- a/src/Content/Petabridge.Library/build.sh
+++ b/src/Content/Petabridge.Library/build.sh
@@ -10,9 +10,8 @@ NUGET_EXE=$TOOLS_DIR/nuget.exe
 NUGET_URL=https://dist.nuget.org/win-x86-commandline/v4.0.0/nuget.exe
 FAKE_VERSION=4.61.2
 FAKE_EXE=$TOOLS_DIR/FAKE/tools/FAKE.exe
-DOTNET_VERSION=1.0.4
-DOTNET_INSTALLER_URL=https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh
-
+DOTNET_VERSION=2.0.0
+DOTNET_INSTALLER_URL=https://raw.githubusercontent.com/dotnet/cli/2.0.0/scripts/obtain/dotnet-install.sh
 # Define default arguments.
 TARGET="Default"
 CONFIGURATION="Release"

--- a/src/Content/Petabridge.Library/serve-docs.cmd
+++ b/src/Content/Petabridge.Library/serve-docs.cmd
@@ -1,0 +1,1 @@
+PowerShell.exe -file "serve-docs.ps1" %*  .\docs\docfx.json --serve -p 8090

--- a/src/Content/Petabridge.Library/serve-docs.ps1
+++ b/src/Content/Petabridge.Library/serve-docs.ps1
@@ -1,0 +1,21 @@
+# docfx.ps1
+$VisualStudioVersion = "15.0";
+$DotnetSDKVersion = "2.0.0";
+
+# Get dotnet paths
+$MSBuildExtensionsPath = "C:\Program Files\dotnet\sdk\" + $DotnetSDKVersion;
+$MSBuildSDKsPath = $MSBuildExtensionsPath + "\SDKs";
+
+# Get Visual Studio install path
+$VSINSTALLDIR =  $(Get-ItemProperty "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\SxS\VS7").$VisualStudioVersion;
+
+# Add Visual Studio environment variables
+$env:VisualStudioVersion = $VisualStudioVersion;
+$env:VSINSTALLDIR = $VSINSTALLDIR;
+
+# Add dotnet environment variables
+$env:MSBuildExtensionsPath = $MSBuildExtensionsPath;
+$env:MSBuildSDKsPath = $MSBuildSDKsPath;
+
+# Build our docs
+& .\tools\docfx.console\tools\docfx @args

--- a/src/Content/Petabridge.Library/src/Petabridge.Library.Tests.Performance/Petabridge.Library.Tests.Performance.csproj
+++ b/src/Content/Petabridge.Library/src/Petabridge.Library.Tests.Performance/Petabridge.Library.Tests.Performance.csproj
@@ -3,7 +3,7 @@
 
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Content/Petabridge.Library/src/Petabridge.Library.Tests.Performance/Petabridge.Library.Tests.Performance.csproj
+++ b/src/Content/Petabridge.Library/src/Petabridge.Library.Tests.Performance/Petabridge.Library.Tests.Performance.csproj
@@ -3,11 +3,11 @@
 
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NBench" Version="1.0.4" />
   </ItemGroup>
 

--- a/src/Content/Petabridge.Library/src/Petabridge.Library.Tests/Petabridge.Library.Tests.csproj
+++ b/src/Content/Petabridge.Library/src/Petabridge.Library.Tests/Petabridge.Library.Tests.csproj
@@ -2,11 +2,11 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(XunitVersion)" />
   </ItemGroup>

--- a/src/Content/Petabridge.Library/src/Petabridge.Library/Petabridge.Library.csproj
+++ b/src/Content/Petabridge.Library/src/Petabridge.Library/Petabridge.Library.csproj
@@ -3,7 +3,7 @@
 
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/Content/Petabridge.Library/src/common.props
+++ b/src/Content/Petabridge.Library/src/common.props
@@ -11,5 +11,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <XunitVersion>2.3.0</XunitVersion>
+    <TestSdkVersion>15.3.0</TestSdkVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### 0.2.0 January 17 2018 ####
* [Upgrade template to .NET Standard 2.0](https://github.com/petabridge/petabridge-dotnet-new/issues/28).
* [See the full v0.2.0 change set here](https://github.com/petabridge/petabridge-dotnet-new/milestone/1).
