### PR TITLE
added v0.2.1 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,12 @@
+#### 0.2.1 April 19 2018 ####
+* [Disable NBench by default](https://github.com/petabridge/petabridge-dotnet-new/pull/41)
+* [Add default description tag to projects](https://github.com/petabridge/petabridge-dotnet-new/issues/33)
+* [Add reference to xunit.runner.visualstudio in test projects](https://github.com/petabridge/petabridge-dotnet-new/issues/32)
+* [Change build system to build the entire solution, rather than iterating over individual projects](https://github.com/petabridge/petabridge-dotnet-new/issues/31) - significantly speeds up build times.
+
 #### 0.2.0 January 17 2018 ####
 * [Upgrade template to .NET Standard 2.0](https://github.com/petabridge/petabridge-dotnet-new/issues/28).
 * [See the full v0.2.0 change set here](https://github.com/petabridge/petabridge-dotnet-new/milestone/1).
-
 
 #### 0.1.3 October 18 2017 ####
 * [`build.fsx` can not automatically detect TeamCity and toggle TC formatting on and off for XUnit2 test runs](https://github.com/petabridge/petabridge-dotnet-new/pull/19).


### PR DESCRIPTION
#### 0.2.1 April 19 2018 ####
* [Disable NBench by default](https://github.com/petabridge/petabridge-dotnet-new/pull/41)
* [Add default description tag to projects](https://github.com/petabridge/petabridge-dotnet-new/issues/33)
* [Add reference to xunit.runner.visualstudio in test projects](https://github.com/petabridge/petabridge-dotnet-new/issues/32)
* [Change build system to build the entire solution, rather than iterating over individual projects](https://github.com/petabridge/petabridge-dotnet-new/issues/31) - significantly speeds up build times.
