### PR TITLE
Upgrade to NBench v1.2.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 0.3.1 July 15 2018 ####
+Fixed a minor issue with `build.sh` not working correctly out of the box due to an unexpected parameter in `dotnet-install.sh`.
+
 #### 0.3.0 July 14 2018 ####
 This is a major update to the `Petabridge.Library` `dotnet new` template; most notably it enables .NET Core execution of performance tests using [NBench v1.2.1](https://github.com/petabridge/NBench#running-nbench-tests-with-dotnet-nbench) and the new `dotnet nbench` tool. In addition, we've fixed a number of issues related to DocFx output.
 

--- a/src/Content/Petabridge.Library/src/common.props
+++ b/src/Content/Petabridge.Library/src/common.props
@@ -12,6 +12,6 @@
   <PropertyGroup>
     <XunitVersion>2.3.1</XunitVersion>
     <TestSdkVersion>15.7.2</TestSdkVersion>
-    <NBenchVersion>1.2.1</NBenchVersion>
+    <NBenchVersion>1.2.2</NBenchVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Puts an end to those annoying downgrade warnings: https://github.com/petabridge/NBench/issues/246