### PR TITLE
v0.3.1 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 0.3.1 July 15 2018 ####
+Fixed a minor issue with `build.sh` not working correctly out of the box due to an unexpected parameter in `dotnet-install.sh`.
+
 #### 0.3.0 July 14 2018 ####
 This is a major update to the `Petabridge.Library` `dotnet new` template; most notably it enables .NET Core execution of performance tests using [NBench v1.2.1](https://github.com/petabridge/NBench#running-nbench-tests-with-dotnet-nbench) and the new `dotnet nbench` tool. In addition, we've fixed a number of issues related to DocFx output.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
-#### 0.3.1 July 15 2018 ####
-Fixed a minor issue with `build.sh` not working correctly out of the box due to an unexpected parameter in `dotnet-install.sh`.
+#### 0.3.1 September 07 2018 ####
+* Fixed a minor issue with `build.sh` not working correctly out of the box due to an unexpected parameter in `dotnet-install.sh`.
+* Upgraded to NBench v1.2.2 to avoid NuGet package downgrade warnings.
 
 #### 0.3.0 July 14 2018 ####
 This is a major update to the `Petabridge.Library` `dotnet new` template; most notably it enables .NET Core execution of performance tests using [NBench v1.2.1](https://github.com/petabridge/NBench#running-nbench-tests-with-dotnet-nbench) and the new `dotnet nbench` tool. In addition, we've fixed a number of issues related to DocFx output.

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ NUGET_URL=https://dist.nuget.org/win-x86-commandline/v4.0.0/nuget.exe
 FAKE_VERSION=4.61.2
 FAKE_EXE=$TOOLS_DIR/FAKE/tools/FAKE.exe
 DOTNET_VERSION=2.0.0
-DOTNET_CHANNEL = "LTS";
+DOTNET_CHANNEL=LTS;
 DOTNET_INSTALLER_URL=https://raw.githubusercontent.com/dotnet/cli/v2.0.0/scripts/obtain/dotnet-install.sh
 
 # Define default arguments.
@@ -48,7 +48,7 @@ if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
   mkdir "$SCRIPT_DIR/.dotnet"
 fi
 curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" $DOTNET_INSTALLER_URL
-bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version $DOTNET_VERSION --install-dir .dotnet --no-path
+bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version $DOTNET_VERSION --channel $DOTNET_CHANNEL --install-dir .dotnet --no-path
 export PATH="$SCRIPT_DIR/.dotnet":$PATH
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
   mkdir "$SCRIPT_DIR/.dotnet"
 fi
 curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" $DOTNET_INSTALLER_URL
-bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version $DOTNET_VERSION --channel $DOTNET_CHANNEL --install-dir .dotnet --no-path
+bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version $DOTNET_VERSION --install-dir .dotnet --no-path
 export PATH="$SCRIPT_DIR/.dotnet":$PATH
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/src/Content/Petabridge.Library/build.sh
+++ b/src/Content/Petabridge.Library/build.sh
@@ -11,7 +11,7 @@ NUGET_URL=https://dist.nuget.org/win-x86-commandline/v4.0.0/nuget.exe
 FAKE_VERSION=4.61.2
 FAKE_EXE=$TOOLS_DIR/FAKE/tools/FAKE.exe
 DOTNET_VERSION=2.0.0
-DOTNET_CHANNEL = "LTS";
+DOTNET_CHANNEL=LTS;
 DOTNET_INSTALLER_URL=https://raw.githubusercontent.com/dotnet/cli/v2.0.0/scripts/obtain/dotnet-install.sh
 
 # Define default arguments.
@@ -48,7 +48,7 @@ if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
   mkdir "$SCRIPT_DIR/.dotnet"
 fi
 curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" $DOTNET_INSTALLER_URL
-bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version $DOTNET_VERSION --install-dir .dotnet --no-path
+bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version $DOTNET_VERSION --channel $DOTNET_CHANNEL --install-dir .dotnet --no-path
 export PATH="$SCRIPT_DIR/.dotnet":$PATH
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/src/Content/Petabridge.Library/build.sh
+++ b/src/Content/Petabridge.Library/build.sh
@@ -48,7 +48,7 @@ if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
   mkdir "$SCRIPT_DIR/.dotnet"
 fi
 curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" $DOTNET_INSTALLER_URL
-bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version $DOTNET_VERSION --channel $DOTNET_CHANNEL --install-dir .dotnet --no-path
+bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version $DOTNET_VERSION --install-dir .dotnet --no-path
 export PATH="$SCRIPT_DIR/.dotnet":$PATH
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/src/Content/Petabridge.Library/src/common.props
+++ b/src/Content/Petabridge.Library/src/common.props
@@ -12,6 +12,6 @@
   <PropertyGroup>
     <XunitVersion>2.3.1</XunitVersion>
     <TestSdkVersion>15.7.2</TestSdkVersion>
-    <NBenchVersion>1.2.1</NBenchVersion>
+    <NBenchVersion>1.2.2</NBenchVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### 0.3.1 September 07 2018 ####
* Fixed a minor issue with `build.sh` not working correctly out of the box due to an unexpected parameter in `dotnet-install.sh`.
* Upgraded to NBench v1.2.2 to avoid NuGet package downgrade warnings.