### PR TITLE
Improve pre-release system

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 0.4.0 December 21 2018 ####
+Version bump.
+
 #### 0.3.1 September 07 2018 ####
 * Fixed a minor issue with `build.sh` not working correctly out of the box due to an unexpected parameter in `dotnet-install.sh`.
 * Upgraded to NBench v1.2.2 to avoid NuGet package downgrade warnings.

--- a/build.fsx
+++ b/build.fsx
@@ -82,7 +82,7 @@ Target "CreateNuget" (fun _ ->
                         Project =  project
                         Properties = ["Configuration", "Release"]
                         ReleaseNotes = releaseNotes.Notes |> String.concat "\n"
-                        Version = releaseVersion
+                        Version = [ releaseVersion; versionSuffix;] |> String.concat "-"
                         Tags = tags |> String.concat " "
                         OutputPath = outputDir
                         WorkingDir = workingDir})

--- a/build.fsx
+++ b/build.fsx
@@ -20,7 +20,7 @@ let configuration = "Release"
 
 // Read release notes and version
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
-let preReleaseVersionSuffix = (if (not (buildNumber = "0")) then (buildNumber) else "") + "-beta"
+let preReleaseVersionSuffix = "beta" + (if (not (buildNumber = "0")) then (buildNumber) else DateTime.UtcNow.Ticks.ToString())
 let versionSuffix = 
     match (getBuildParam "nugetprerelease") with
     | "dev" -> preReleaseVersionSuffix

--- a/build.fsx
+++ b/build.fsx
@@ -20,7 +20,7 @@ let configuration = "Release"
 
 // Read release notes and version
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
-let preReleaseVersionSuffix = "beta" + (if (not (buildNumber = "0")) then (buildNumber) else DateTime.UtcNow.Ticks.ToString())
+let preReleaseVersionSuffix = "-beta" + (if (not (buildNumber = "0")) then (buildNumber) else DateTime.UtcNow.Ticks.ToString())
 let versionSuffix = 
     match (getBuildParam "nugetprerelease") with
     | "dev" -> preReleaseVersionSuffix
@@ -82,7 +82,7 @@ Target "CreateNuget" (fun _ ->
                         Project =  project
                         Properties = ["Configuration", "Release"]
                         ReleaseNotes = releaseNotes.Notes |> String.concat "\n"
-                        Version = [ releaseVersion; versionSuffix;] |> String.concat "-"
+                        Version = [ releaseVersion; versionSuffix;] |> String.concat ""
                         Tags = tags |> String.concat " "
                         OutputPath = outputDir
                         WorkingDir = workingDir})

--- a/src/Content/Petabridge.Library/build.fsx
+++ b/src/Content/Petabridge.Library/build.fsx
@@ -17,7 +17,7 @@ let configuration = "Release"
 let solutionFile = FindFirstMatchingFile "*.sln" __SOURCE_DIRECTORY__  // dynamically look up the solution
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
 let hasTeamCity = (not (buildNumber = "0")) // check if we have the TeamCity environment variable for build # set
-let preReleaseVersionSuffix = (if (not (buildNumber = "0")) then (buildNumber) else "") + "-beta"
+let preReleaseVersionSuffix = "beta" + (if (not (buildNumber = "0")) then (buildNumber) else DateTime.UtcNow.Ticks.ToString())
 let versionSuffix = 
     match (getBuildParam "nugetprerelease") with
     | "dev" -> preReleaseVersionSuffix

--- a/src/Content/Petabridge.Library/src/Petabridge.Library.Tests.Performance/Petabridge.Library.Tests.Performance.csproj
+++ b/src/Content/Petabridge.Library/src/Petabridge.Library.Tests.Performance/Petabridge.Library.Tests.Performance.csproj
@@ -4,6 +4,8 @@
 
   <PropertyGroup>    
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <RuntimeFrameworkVersion>2.1.6</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
made the pre-release version numbering system use the current DateTime.UtcNow.Ticks for numbering beta releases if TC environment vars aren't available