### PR TITLE
v0.4.0 Production Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 #### 0.4.0 December 21 2018 ####
-Version bump.
+* Upgraded all new projects to use .NET Core 2.1;
+* Migrated testing system to use XUnit 2.4.1 and the 15.9.0 version of the Microsoft Test SDK;
+* [Migrated all tests to execute via `dotnet test`](https://github.com/petabridge/petabridge-dotnet-new/pull/73), since `dotnet xunit` is now officially deprecated;
+* [Added code-signing for all NuGet packages via SignService](https://github.com/petabridge/petabridge-dotnet-new/issues/72); and
+* Improved the `nugetprerelease=dev` system such that it can now generate beta version numbers incrementally using the `DateTime.UtcNow.Ticks` value.
+
+For the [full set of changes in `Petabridge.Templates` v0.4.0, click here](https://github.com/petabridge/petabridge-dotnet-new/milestone/4).
 
 #### 0.3.1 September 07 2018 ####
 * Fixed a minor issue with `build.sh` not working correctly out of the box due to an unexpected parameter in `dotnet-install.sh`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 0.4.0 December 21 2018 ####
+Version bump.
+
 #### 0.3.1 September 07 2018 ####
 * Fixed a minor issue with `build.sh` not working correctly out of the box due to an unexpected parameter in `dotnet-install.sh`.
 * Upgraded to NBench v1.2.2 to avoid NuGet package downgrade warnings.

--- a/build.fsx
+++ b/build.fsx
@@ -20,7 +20,7 @@ let configuration = "Release"
 
 // Read release notes and version
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
-let preReleaseVersionSuffix = (if (not (buildNumber = "0")) then (buildNumber) else "") + "-beta"
+let preReleaseVersionSuffix = "-beta" + (if (not (buildNumber = "0")) then (buildNumber) else DateTime.UtcNow.Ticks.ToString())
 let versionSuffix = 
     match (getBuildParam "nugetprerelease") with
     | "dev" -> preReleaseVersionSuffix
@@ -82,7 +82,7 @@ Target "CreateNuget" (fun _ ->
                         Project =  project
                         Properties = ["Configuration", "Release"]
                         ReleaseNotes = releaseNotes.Notes |> String.concat "\n"
-                        Version = releaseVersion
+                        Version = [ releaseVersion; versionSuffix;] |> String.concat ""
                         Tags = tags |> String.concat " "
                         OutputPath = outputDir
                         WorkingDir = workingDir})

--- a/build.ps1
+++ b/build.ps1
@@ -128,6 +128,20 @@ if (!(Test-Path $DocfxExePath)) {
 }
 
 ###########################################################################
+# SignTool
+###########################################################################
+
+# Make sure the SignClient has been installed
+if (Get-Command signclient -ErrorAction SilentlyContinue) {
+    Write-Host "Found SignClient. Skipping install."
+}
+else{
+    $SignClientFolder = Join-Path $ToolPath "signclient"
+    Write-Host "SignClient not found. Installing to ... $SignClientFolder"
+    dotnet tool install SignClient --version 1.0.82 --tool-path "$SignClientFolder"
+}
+
+###########################################################################
 # RUN BUILD SCRIPT
 ###########################################################################
 

--- a/build.sh
+++ b/build.sh
@@ -88,6 +88,16 @@ if [ ! -f "$FAKE_EXE" ]; then
 fi
 
 ###########################################################################
+# INSTALL SignTool
+###########################################################################
+if [ ! -f "$SIGNTOOL_EXE" ]; then
+    "$SCRIPT_DIR/.dotnet/dotnet" tool install SignClient --version 1.0.82 --tool-path "$SIGNCLIENT_DIR"
+    if [ $? -ne 0 ]; then
+        echo "SignClient already installed."
+    fi
+fi
+
+###########################################################################
 # WORKAROUND FOR MONO
 ###########################################################################
 export FrameworkPathOverride=/usr/lib/mono/4.5/

--- a/src/Content/Petabridge.Library/README.md
+++ b/src/Content/Petabridge.Library/README.md
@@ -50,3 +50,21 @@ If you add any new projects to the solution created with this template, be sure 
 ```
 <Import Project="..\common.props" />
 ```
+
+### Code Signing via SignService
+This project uses [SignService](https://github.com/onovotny/SignService) to code-sign NuGet packages prior to publication. The `build.cmd` and `build.sh` scripts will automatically download the `SignClient` needed to execute code signing locally on the build agent, but it's still your responsibility to set up the SignService server per the instructions at the linked repository.
+
+Once you've gone through the ropes of setting up a code-signing server, you'll need to set a few configuration options in your project in order to use the `SignClient`:
+
+* Add your Active Directory settings to [`appsettings.json`](appsettings.json) and
+* Pass in your signature information to the `signingName`, `signingDescription`, and `signingUrl` values inside `build.fsx`.
+
+Whenever you're ready to run code-signing on the NuGet packages published by `build.fsx`, execute the following command:
+
+```
+C:\> build.cmd nuget SignClientSecret={your secret} SignClientUser={your username}
+```
+
+This will invoke the `SignClient` and actually execute code signing against your `.nupkg` files prior to NuGet publication.
+
+If one of these two values isn't provided, the code signing stage will skip itself and simply produce unsigned NuGet code packages.

--- a/src/Content/Petabridge.Library/appsettings.json
+++ b/src/Content/Petabridge.Library/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "SignClient": {
+    "AzureAd": {
+      "AADInstance": "https://login.microsoftonline.com/",
+      "ClientId": "",
+      "TenantId": ""
+    },
+    "Service": {
+      "Url": "",
+      "ResourceId": ""
+    }
+  }
+}

--- a/src/Content/Petabridge.Library/build.fsx
+++ b/src/Content/Petabridge.Library/build.fsx
@@ -17,7 +17,7 @@ let configuration = "Release"
 let solutionFile = FindFirstMatchingFile "*.sln" __SOURCE_DIRECTORY__  // dynamically look up the solution
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
 let hasTeamCity = (not (buildNumber = "0")) // check if we have the TeamCity environment variable for build # set
-let preReleaseVersionSuffix = (if (not (buildNumber = "0")) then (buildNumber) else "") + "-beta"
+let preReleaseVersionSuffix = "beta" + (if (not (buildNumber = "0")) then (buildNumber) else DateTime.UtcNow.Ticks.ToString())
 let versionSuffix = 
     match (getBuildParam "nugetprerelease") with
     | "dev" -> preReleaseVersionSuffix

--- a/src/Content/Petabridge.Library/build.fsx
+++ b/src/Content/Petabridge.Library/build.fsx
@@ -13,6 +13,11 @@ open Fake.DocFxHelper
 let product = "Petabridge.Library"
 let configuration = "Release"
 
+// Metadata used when signing packages and DLLs
+let signingName = "My Library"
+let signingDescription = "My REALLY COOL Library"
+let signingUrl = "https://signing.is.cool/"
+
 // Read release notes and version
 let solutionFile = FindFirstMatchingFile "*.sln" __SOURCE_DIRECTORY__  // dynamically look up the solution
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
@@ -140,6 +145,54 @@ Target "NBench" <| fun _ ->
 
 
 //--------------------------------------------------------------------------------
+// Code signing targets
+//--------------------------------------------------------------------------------
+Target "SignPackages" (fun _ ->
+    let canSign = hasBuildParam "SignClientSecret" && hasBuildParam "SignClientUser"
+    if(canSign) then
+        log "Signing information is available."
+        
+        let assemblies = !! (outputNuGet @@ "*.nupkg")
+
+        let signPath =
+            let globalTool = tryFindFileOnPath "SignClient.exe"
+            match globalTool with
+                | Some t -> t
+                | None -> if isWindows then findToolInSubPath "SignClient.exe" "tools/signclient"
+                          elif isMacOS then findToolInSubPath "SignClient" "tools/signclient"
+                          else findToolInSubPath "SignClient" "tools/signclient"
+
+        let signAssembly assembly =
+            let args = StringBuilder()
+                    |> append "sign"
+                    |> append "--config"
+                    |> append (__SOURCE_DIRECTORY__ @@ "appsettings.json") 
+                    |> append "-i"
+                    |> append assembly
+                    |> append "-r"
+                    |> append (getBuildParam "SignClientUser")
+                    |> append "-s"
+                    |> append (getBuildParam "SignClientSecret")
+                    |> append "-n"
+                    |> append signingName
+                    |> append "-d"
+                    |> append signingDescription
+                    |> append "-u"
+                    |> append signingUrl
+                    |> toText
+
+            let result = ExecProcess(fun info -> 
+                info.FileName <- signPath
+                info.WorkingDirectory <- __SOURCE_DIRECTORY__
+                info.Arguments <- args) (System.TimeSpan.FromMinutes 5.0) (* Reasonably long-running task. *)
+            if result <> 0 then failwithf "SignClient failed.%s" args
+
+        assemblies |> Seq.iter (signAssembly)
+    else
+        log "SignClientSecret not available. Skipping signing"
+)
+
+//--------------------------------------------------------------------------------
 // Nuget targets 
 //--------------------------------------------------------------------------------
 
@@ -230,11 +283,12 @@ Target "Help" <| fun _ ->
       "./build.ps1 [target]"
       ""
       " Targets for building:"
-      " * Build      Builds"
-      " * Nuget      Create and optionally publish nugets packages"
-      " * RunTests   Runs tests"
-      " * All        Builds, run tests, creates and optionally publish nuget packages"
-      " * DocFx      Creates a DocFx-based website for this solution"
+      " * Build         Builds"
+      " * Nuget         Create and optionally publish nugets packages"
+      " * SignPackages  Signs all NuGet packages, provided that the following arguments are passed into the script: SignClientSecret={secret} and SignClientUser={username}"
+      " * RunTests      Runs tests"
+      " * All           Builds, run tests, creates and optionally publish nuget packages"
+      " * DocFx         Creates a DocFx-based website for this solution"
       ""
       " Other Targets"
       " * Help       Display this help" 
@@ -256,7 +310,7 @@ Target "Nuget" DoNothing
 
 // nuget dependencies
 "Clean" ==> "RestorePackages" ==> "Build" ==> "CreateNuget"
-"CreateNuget" ==> "PublishNuget" ==> "Nuget"
+"CreateNuget" ==> "SignPackages" ==> "PublishNuget" ==> "Nuget"
 
 // docs
 "Clean" ==> "RestorePackages" ==> "BuildRelease" ==> "Docfx"

--- a/src/Content/Petabridge.Library/build.ps1
+++ b/src/Content/Petabridge.Library/build.ps1
@@ -31,11 +31,11 @@ Param(
 
 $FakeVersion = "4.61.2"
 $DotNetChannel = "LTS";
-$DotNetVersion = "2.0.0";
-$DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/v2.0.0/scripts/obtain/dotnet-install.ps1";
+$DotNetVersion = "2.1.500";
+$DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/v$DotNetVersion/scripts/obtain/dotnet-install.ps1";
 $NugetVersion = "4.1.0";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe"
-$ProtobufVersion = "3.2.0"
+$ProtobufVersion = "3.4.0"
 $DocfxVersion = "2.36.2"
 
 # Make sure tools folder exists

--- a/src/Content/Petabridge.Library/build.sh
+++ b/src/Content/Petabridge.Library/build.sh
@@ -6,13 +6,14 @@
 # Define directories.
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 TOOLS_DIR=$SCRIPT_DIR/tools
+SIGNCLIENT_DIR=$TOOLS_DIR/signclient
 NUGET_EXE=$TOOLS_DIR/nuget.exe
 NUGET_URL=https://dist.nuget.org/win-x86-commandline/v4.0.0/nuget.exe
 FAKE_VERSION=4.61.2
 FAKE_EXE=$TOOLS_DIR/FAKE/tools/FAKE.exe
-DOTNET_VERSION=2.0.0
+DOTNET_VERSION=2.1.500
+DOTNET_INSTALLER_URL=https://raw.githubusercontent.com/dotnet/cli/v$DOTNET_VERSION/scripts/obtain/dotnet-install.sh
 DOTNET_CHANNEL=LTS;
-DOTNET_INSTALLER_URL=https://raw.githubusercontent.com/dotnet/cli/v2.0.0/scripts/obtain/dotnet-install.sh
 
 # Define default arguments.
 TARGET="Default"

--- a/src/Content/Petabridge.Library/src/Petabridge.Library.Tests.Performance/Petabridge.Library.Tests.Performance.csproj
+++ b/src/Content/Petabridge.Library/src/Petabridge.Library.Tests.Performance/Petabridge.Library.Tests.Performance.csproj
@@ -3,7 +3,7 @@
 
 
   <PropertyGroup>    
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Content/Petabridge.Library/src/Petabridge.Library.Tests.Performance/Petabridge.Library.Tests.Performance.csproj
+++ b/src/Content/Petabridge.Library/src/Petabridge.Library.Tests.Performance/Petabridge.Library.Tests.Performance.csproj
@@ -4,6 +4,8 @@
 
   <PropertyGroup>    
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <RuntimeFrameworkVersion>2.1.6</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Content/Petabridge.Library/src/Petabridge.Library.Tests/Petabridge.Library.Tests.csproj
+++ b/src/Content/Petabridge.Library/src/Petabridge.Library.Tests/Petabridge.Library.Tests.csproj
@@ -2,13 +2,12 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 

--- a/src/Content/Petabridge.Library/src/common.props
+++ b/src/Content/Petabridge.Library/src/common.props
@@ -10,8 +10,8 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    <XunitVersion>2.3.1</XunitVersion>
-    <TestSdkVersion>15.7.2</TestSdkVersion>
     <NBenchVersion>1.2.2</NBenchVersion>
+    <XunitVersion>2.4.1</XunitVersion>
+    <TestSdkVersion>15.9.0</TestSdkVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### 0.4.0 December 21 2018 ####
* Upgraded all new projects to use .NET Core 2.1;
* Migrated testing system to use XUnit 2.4.1 and the 15.9.0 version of the Microsoft Test SDK;
* [Migrated all tests to execute via `dotnet test`](https://github.com/petabridge/petabridge-dotnet-new/pull/73), since `dotnet xunit` is now officially deprecated;
* [Added code-signing for all NuGet packages via SignService](https://github.com/petabridge/petabridge-dotnet-new/issues/72); and
* Improved the `nugetprerelease=dev` system such that it can now generate beta version numbers incrementally using the `DateTime.UtcNow.Ticks` value.

For the [full set of changes in `Petabridge.Templates` v0.4.0, click here](https://github.com/petabridge/petabridge-dotnet-new/milestone/4).