### PR TITLE
v0.4.1 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
-#### 0.4.1 December 29 2018 ####
+#### 0.4.1 December 30 2018 ####
 * Fixed an issue with the `dotnet test` stage that caused it to prematurely fail, rather than run all the way to completion.
+* Added DocFx support to `build.sh` and bumped DocFx version to 2.40.5
 
 #### 0.4.0 December 21 2018 ####
 * Upgraded all new projects to use .NET Core 2.1;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 0.4.1 December 29 2018 ####
+* Fixed an issue with the `dotnet test` stage that caused it to prematurely fail, rather than run all the way to completion.
+
 #### 0.4.0 December 21 2018 ####
 * Upgraded all new projects to use .NET Core 2.1;
 * Migrated testing system to use XUnit 2.4.1 and the 15.9.0 version of the Microsoft Test SDK;

--- a/src/Content/Petabridge.Library/build.fsx
+++ b/src/Content/Petabridge.Library/build.fsx
@@ -103,19 +103,18 @@ Target "RunTests" (fun _ ->
         | true -> !! "./src/**/*.Tests.csproj"
         | _ -> !! "./src/**/*.Tests.csproj" // if you need to filter specs for Linux vs. Windows, do it here
 
-    let runSingleProject project =
+     let runSingleProject project =
         let arguments =
             match (hasTeamCity) with
-            | true -> (sprintf "--no-build --logger:\"console;verbosity=normal\" --results-directory %s -- -parallel none -teamcity" (outputTests))
-            | false -> (sprintf "--no-build --logger:\"console;verbosity=normal\" --results-directory %s -- -parallel none" (outputTests))
+            | true -> (sprintf "test -c Release --no-build --logger:\"console;verbosity=normal\" --results-directory %s -- -parallel none -teamcity" (outputTests))
+            | false -> (sprintf "test -c Release --no-build --logger:\"console;verbosity=normal\" --results-directory %s -- -parallel none" (outputTests))
 
-        DotNetCli.Test
-            (fun t -> 
-                { t with 
-                    Project = project
-                    Configuration = configuration
-                    AdditionalArgs = [arguments]
-                })
+        let result = ExecProcess(fun info ->
+            info.FileName <- "dotnet"
+            info.WorkingDirectory <- (Directory.GetParent project).FullName
+            info.Arguments <- arguments) (TimeSpan.FromMinutes 30.0) 
+        
+        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.DontFailBuild result  
 
     projects |> Seq.iter (log)
     projects |> Seq.iter (runSingleProject)

--- a/src/Content/Petabridge.Library/build.ps1
+++ b/src/Content/Petabridge.Library/build.ps1
@@ -36,7 +36,7 @@ $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/v$DotNetVers
 $NugetVersion = "4.1.0";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe"
 $ProtobufVersion = "3.4.0"
-$DocfxVersion = "2.36.2"
+$DocfxVersion = "2.40.5"
 
 # Make sure tools folder exists
 $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent

--- a/src/Content/Petabridge.Library/build.sh
+++ b/src/Content/Petabridge.Library/build.sh
@@ -14,6 +14,8 @@ FAKE_EXE=$TOOLS_DIR/FAKE/tools/FAKE.exe
 DOTNET_VERSION=2.1.500
 DOTNET_INSTALLER_URL=https://raw.githubusercontent.com/dotnet/cli/v$DOTNET_VERSION/scripts/obtain/dotnet-install.sh
 DOTNET_CHANNEL=LTS;
+DOCFX_VERSION=2.40.5
+DOCFX_EXE=$TOOLS_DIR/docfx.console/tools/docfx.exe
 
 # Define default arguments.
 TARGET="Default"
@@ -86,6 +88,23 @@ fi
 # Make sure that Fake has been installed.
 if [ ! -f "$FAKE_EXE" ]; then
     echo "Could not find Fake.exe at '$FAKE_EXE'."
+    exit 1
+fi
+
+###########################################################################
+# INSTALL DOCFX
+###########################################################################
+if [ ! -f "$DOCFX_EXE" ]; then
+    mono "$NUGET_EXE" install docfx.console -ExcludeVersion -Version $DOCFX_VERSION -OutputDirectory "$TOOLS_DIR"
+    if [ $? -ne 0 ]; then
+        echo "An error occured while installing DocFx."
+        exit 1
+    fi
+fi
+
+# Make sure that DocFx has been installed.
+if [ ! -f "$DOCFX_EXE" ]; then
+    echo "Could not find docfx.exe at '$DOCFX_EXE'."
     exit 1
 fi
 


### PR DESCRIPTION
#### 0.4.1 December 30 2018 ####
* Fixed an issue with the `dotnet test` stage that caused it to prematurely fail, rather than run all the way to completion.
* Added DocFx support to `build.sh` and bumped DocFx version to 2.40.5