### PR TITLE
v0.4.3 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 0.4.3 February 17 2019 ####
+* [Fixed: Need to return non-zero exit code when NBench or XUnit tests fail](https://github.com/petabridge/petabridge-dotnet-new/issues/86).
+
 #### 0.4.2 December 31 2018 ####
 * Fixed a bug with the `RunTests` step that caused `build.fsx` to fail to execute.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 0.4.2 December 31 2018 ####
+* Fixed a bug with the `RunTests` step that caused `build.fsx` to fail to execute.
+
 #### 0.4.1 December 30 2018 ####
 * Fixed an issue with the `dotnet test` stage that caused it to prematurely fail, rather than run all the way to completion.
 * Added DocFx support to `build.sh` and bumped DocFx version to 2.40.5

--- a/src/Content/Petabridge.Library/build.fsx
+++ b/src/Content/Petabridge.Library/build.fsx
@@ -103,7 +103,7 @@ Target "RunTests" (fun _ ->
         | true -> !! "./src/**/*.Tests.csproj"
         | _ -> !! "./src/**/*.Tests.csproj" // if you need to filter specs for Linux vs. Windows, do it here
 
-     let runSingleProject project =
+    let runSingleProject project =
         let arguments =
             match (hasTeamCity) with
             | true -> (sprintf "test -c Release --no-build --logger:\"console;verbosity=normal\" --results-directory %s -- -parallel none -teamcity" (outputTests))

--- a/src/Content/Petabridge.Library/build.fsx
+++ b/src/Content/Petabridge.Library/build.fsx
@@ -39,11 +39,6 @@ let outputTests = __SOURCE_DIRECTORY__ @@ "TestResults"
 let outputPerfTests = __SOURCE_DIRECTORY__ @@ "PerfResults"
 let outputNuGet = output @@ "nuget"
 
-// Copied from original NugetCreate target
-let nugetDir = output @@ "nuget"
-let workingDir = output @@ "build"
-let nugetExe = FullName @"./tools/nuget.exe"
-
 Target "Clean" (fun _ ->
     ActivateFinalTarget "KillCreatedProcesses"
 
@@ -114,7 +109,7 @@ Target "RunTests" (fun _ ->
             info.WorkingDirectory <- (Directory.GetParent project).FullName
             info.Arguments <- arguments) (TimeSpan.FromMinutes 30.0) 
         
-        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.DontFailBuild result  
+        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.Error result  
 
     projects |> Seq.iter (log)
     projects |> Seq.iter (runSingleProject)
@@ -138,7 +133,7 @@ Target "NBench" <| fun _ ->
             info.WorkingDirectory <- (Directory.GetParent project).FullName
             info.Arguments <- arguments) (TimeSpan.FromMinutes 30.0) 
         
-        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.DontFailBuild result
+        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.Error result
     
     projects |> Seq.iter runSingleProject
 


### PR DESCRIPTION
#### 0.4.3 February 17 2019 ####
* [Fixed: Need to return non-zero exit code when NBench or XUnit tests fail](https://github.com/petabridge/petabridge-dotnet-new/issues/86).