### PR TITLE
added v0.5.1 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 0.5.1 March 07 2019 ####
+#### 0.5.1 March 14 2019 ####
 **Bugfix Release for Petabridge.Templates v0.5.0**
 
 * Fixed Azure Pipelines YAML - now properly supports build triggers and test reporting.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,6 @@
-#### 0.5.0 March 07 2019 ####
-`Petabridge.Templates` now comes with default [Azure DevOps Pipelines YAML files](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema), found in the `/build-system` folder in each new project created via the `pb-lib` `dotnet new` template.
+#### 0.5.1 March 07 2019 ####
+**Bugfix Release for Petabridge.Templates v0.5.0**
 
-There are three files total:
-
-* `linux-pr-validation.yaml` runs the `build.sh all` command for pull requests on hosted Ubuntu 16.04 VMs.
-* `windows-pr-validation.yaml` runs the `build.cmd all` command for pull requested on hosted Windows Server 2016 VMs.
-* `windows-release.yaml` runs the full code signing and publication package for your project, plus it creates an automatic release on Github afterwards including all of the signed build artifacts.
+* Fixed Azure Pipelines YAML - now properly supports build triggers and test reporting.
+* Modified `RunTests` task to emit `vtx` files for use in Azure Pipelines. TeamCity integration still works.
+* Removed separate `Restore` phase from builds since `dotnet build` handles this implicitly now.


### PR DESCRIPTION
#### 0.5.1 March 14 2019 ####
**Bugfix Release for Petabridge.Templates v0.5.0**

* Fixed Azure Pipelines YAML - now properly supports build triggers and test reporting.
* Modified `RunTests` task to emit `vtx` files for use in Azure Pipelines. TeamCity integration still works.
* Removed separate `Restore` phase from builds since `dotnet build` handles this implicitly now.