### PR TITLE
v0.5.2 Production Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,6 @@
-#### 0.5.0 March 07 2019 ####
-`Petabridge.Templates` now comes with default [Azure DevOps Pipelines YAML files](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema), found in the `/build-system` folder in each new project created via the `pb-lib` `dotnet new` template.
+#### 0.5.1 March 14 2019 ####
+**Bugfix Release for Petabridge.Templates v0.5.0**
 
-There are three files total:
-
-* `linux-pr-validation.yaml` runs the `build.sh all` command for pull requests on hosted Ubuntu 16.04 VMs.
-* `windows-pr-validation.yaml` runs the `build.cmd all` command for pull requested on hosted Windows Server 2016 VMs.
-* `windows-release.yaml` runs the full code signing and publication package for your project, plus it creates an automatic release on Github afterwards including all of the signed build artifacts.
+* Fixed Azure Pipelines YAML - now properly supports build triggers and test reporting.
+* Modified `RunTests` task to emit `vtx` files for use in Azure Pipelines. TeamCity integration still works.
+* Removed separate `Restore` phase from builds since `dotnet build` handles this implicitly now.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,4 @@
-#### 0.5.1 March 14 2019 ####
+#### 0.5.2 March 14 2019 ####
 **Bugfix Release for Petabridge.Templates v0.5.0**
 
-* Fixed Azure Pipelines YAML - now properly supports build triggers and test reporting.
-* Modified `RunTests` task to emit `vtx` files for use in Azure Pipelines. TeamCity integration still works.
-* Removed separate `Restore` phase from builds since `dotnet build` handles this implicitly now.
+* Removed unnecessary `RestorePackages` step from `DocFx` build pipeline

--- a/src/Content/Petabridge.Library/build.fsx
+++ b/src/Content/Petabridge.Library/build.fsx
@@ -54,14 +54,6 @@ Target "AssemblyInfo" (fun _ ->
     XmlPokeInnerText "./src/common.props" "//Project/PropertyGroup/PackageReleaseNotes" (releaseNotes.Notes |> String.concat "\n")
 )
 
-Target "RestorePackages" (fun _ ->
-    DotNetCli.Restore
-        (fun p -> 
-            { p with
-                Project = solutionFile
-                NoCache = false })
-)
-
 Target "Build" (fun _ ->          
     DotNetCli.Build
         (fun p -> 
@@ -297,13 +289,13 @@ Target "All" DoNothing
 Target "Nuget" DoNothing
 
 // build dependencies
-"Clean" ==> "RestorePackages" ==> "AssemblyInfo" ==> "Build" ==> "BuildRelease"
+"Clean" ==> "AssemblyInfo" ==> "Build" ==> "BuildRelease"
 
 // tests dependencies
-"Clean" ==> "RestorePackages" ==> "Build" ==> "RunTests"
+"Build" ==> "RunTests"
 
 // nuget dependencies
-"Clean" ==> "RestorePackages" ==> "Build" ==> "CreateNuget"
+"Clean" ==> "Build" ==> "CreateNuget"
 "CreateNuget" ==> "SignPackages" ==> "PublishNuget" ==> "Nuget"
 
 // docs

--- a/src/Content/Petabridge.Library/build.fsx
+++ b/src/Content/Petabridge.Library/build.fsx
@@ -299,7 +299,7 @@ Target "Nuget" DoNothing
 "CreateNuget" ==> "SignPackages" ==> "PublishNuget" ==> "Nuget"
 
 // docs
-"Clean" ==> "RestorePackages" ==> "BuildRelease" ==> "Docfx"
+"Clean" ==> "BuildRelease" ==> "Docfx"
 
 // all
 "BuildRelease" ==> "All"


### PR DESCRIPTION
#### 0.5.2 March 14 2019 ####
**Bugfix Release for Petabridge.Templates v0.5.0**

* Removed unnecessary `RestorePackages` step from `DocFx` build pipeline