### PR TITLE
added 0.5.3 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,6 @@
-#### 0.5.2 March 14 2019 ####
+#### 0.5.3 August 05 2019 ####
 **Bugfix Release for Petabridge.Templates v0.5.0**
 
-* Removed unnecessary `RestorePackages` step from `DocFx` build pipeline
+* [Disabled PR validation for release builds](https://github.com/petabridge/petabridge-dotnet-new/issues/106).
+* [Added nightly build template](https://github.com/petabridge/petabridge-dotnet-new/issues/107).
+* [Always bundle NuGet packages as artifacts](https://github.com/petabridge/petabridge-dotnet-new/issues/105).


### PR DESCRIPTION
#### 0.5.3 August 05 2019 ####
**Bugfix Release for Petabridge.Templates v0.5.0**

* [Disabled PR validation for release builds](https://github.com/petabridge/petabridge-dotnet-new/issues/106).
* [Added nightly build template](https://github.com/petabridge/petabridge-dotnet-new/issues/107).
* [Always bundle NuGet packages as artifacts](https://github.com/petabridge/petabridge-dotnet-new/issues/105).