### PR TITLE
v0.5.3 Production Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,6 @@
-#### 0.5.2 March 14 2019 ####
+#### 0.5.3 August 05 2019 ####
 **Bugfix Release for Petabridge.Templates v0.5.0**
 
-* Removed unnecessary `RestorePackages` step from `DocFx` build pipeline
+* [Disabled PR validation for release builds](https://github.com/petabridge/petabridge-dotnet-new/issues/106).
+* [Added nightly build template](https://github.com/petabridge/petabridge-dotnet-new/issues/107).
+* [Always bundle NuGet packages as artifacts](https://github.com/petabridge/petabridge-dotnet-new/issues/105).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,6 @@
-#### 0.5.0 March 07 2019 ####
-`Petabridge.Templates` now comes with default [Azure DevOps Pipelines YAML files](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema), found in the `/build-system` folder in each new project created via the `pb-lib` `dotnet new` template.
+#### 0.5.1 March 14 2019 ####
+**Bugfix Release for Petabridge.Templates v0.5.0**
 
-There are three files total:
-
-* `linux-pr-validation.yaml` runs the `build.sh all` command for pull requests on hosted Ubuntu 16.04 VMs.
-* `windows-pr-validation.yaml` runs the `build.cmd all` command for pull requested on hosted Windows Server 2016 VMs.
-* `windows-release.yaml` runs the full code signing and publication package for your project, plus it creates an automatic release on Github afterwards including all of the signed build artifacts.
+* Fixed Azure Pipelines YAML - now properly supports build triggers and test reporting.
+* Modified `RunTests` task to emit `vtx` files for use in Azure Pipelines. TeamCity integration still works.
+* Removed separate `Restore` phase from builds since `dotnet build` handles this implicitly now.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,4 @@
-#### 0.5.1 March 14 2019 ####
+#### 0.5.2 March 14 2019 ####
 **Bugfix Release for Petabridge.Templates v0.5.0**
 
-* Fixed Azure Pipelines YAML - now properly supports build triggers and test reporting.
-* Modified `RunTests` task to emit `vtx` files for use in Azure Pipelines. TeamCity integration still works.
-* Removed separate `Restore` phase from builds since `dotnet build` handles this implicitly now.
+* Removed unnecessary `RestorePackages` step from `DocFx` build pipeline

--- a/src/Content/Petabridge.Library/build-system/azure-pipeline.template.yaml
+++ b/src/Content/Petabridge.Library/build-system/azure-pipeline.template.yaml
@@ -4,6 +4,7 @@ parameters:
   scriptFileName: ''
   scriptArgs: 'all'
   timeoutInMinutes: 120
+  outputDirectory: 'bin/nuget'
 
 jobs:
   - job: ${{ parameters.name }}
@@ -37,6 +38,17 @@ jobs:
           testResultsFiles: '**/*.trx' #TestResults folder usually
           testRunTitle: ${{ parameters.name }}
           mergeTestResults: true
+      - task: CopyFiles@2
+        displayName: 'Copy Build Output'
+        inputs:
+          sourceFolder: ${{ parameters.outputDirectory }}
+          contents: '**\*'
+          targetFolder: $(Build.ArtifactStagingDirectory)
+          continueOnError: boolean  # 'true' if future steps should run even if this step fails; defaults to 'false'
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          artifactName: ${{ parameters.name }}
       - script: 'echo 1>&2'
         failOnStderr: true
         displayName: 'If above is partially succeeded, then fail'

--- a/src/Content/Petabridge.Library/build-system/nightly-builds.yaml
+++ b/src/Content/Petabridge.Library/build-system/nightly-builds.yaml
@@ -1,0 +1,26 @@
+# Release task for PbLib projects
+# See https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema for reference
+
+pool:
+  vmImage: vs2017-win2016
+  demands: Cmd
+
+trigger: none
+pr: none
+
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily midnight build
+  branches:
+    include:
+    - dev
+
+variables:
+  - group: nugetKeys #create this group with SECRET variables `nugetKey`
+
+steps:
+- task: BatchScript@1
+  displayName: 'FAKE Build'
+  inputs:
+    filename: build.cmd
+    arguments: 'Nuget nugetprerelease=dev nugetpublishurl=$(nightlyUrl) nugetkey=$(nightlyKey)'

--- a/src/Content/Petabridge.Library/build-system/windows-release.yaml
+++ b/src/Content/Petabridge.Library/build-system/windows-release.yaml
@@ -9,6 +9,7 @@ trigger:
   branches:
     include:
       - refs/tags/*
+pr: none
 
 variables:
   - group: signingSecrets #create this group with SECRET variables `signingUsername` and `signingPassword`

--- a/src/Content/Petabridge.Library/build.fsx
+++ b/src/Content/Petabridge.Library/build.fsx
@@ -299,7 +299,7 @@ Target "Nuget" DoNothing
 "CreateNuget" ==> "SignPackages" ==> "PublishNuget" ==> "Nuget"
 
 // docs
-"Clean" ==> "RestorePackages" ==> "BuildRelease" ==> "Docfx"
+"Clean" ==> "BuildRelease" ==> "Docfx"
 
 // all
 "BuildRelease" ==> "All"


### PR DESCRIPTION
#### 0.5.3 August 05 2019 ####
**Bugfix Release for Petabridge.Templates v0.5.0**

* [Disabled PR validation for release builds](https://github.com/petabridge/petabridge-dotnet-new/issues/106).
* [Added nightly build template](https://github.com/petabridge/petabridge-dotnet-new/issues/107).
* [Always bundle NuGet packages as artifacts](https://github.com/petabridge/petabridge-dotnet-new/issues/105).