### PR TITLE
v1.0.2 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ The following templates are installed as part of your `Petabridge.Templates` ins
 
 |    Template Name   | Short Name | Description                                                                                                                                   |
 |:------------------:|------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| [Petabridge.Library](src/Content/Petabridge.Library/README.md) | pb-lib     | A professional .NET Core project setup including build scripts, documentation, unit tests, and performance tests for a class library project. |
+| [Petabridge.Library](https://github.com/petabridge/Petabridge.Library/) | pb-lib     | A professional .NET Core project setup including build scripts, documentation, unit tests, and performance tests for a class library project. |
+| [Petabridge.App](https://github.com/petabridge/Petabridge.App/) | pb-akka-cluster     | Creates a headless .NET Core 3.0 service that includes full [Akka.NET](https://getakka.net/) clustering support, Docker support, documentation, and build systems. |
+| [Petabridge.App.Web](https://github.com/petabridge/Petabridge.App.Web) | pb-akka-web     | Does the same as `pb-akka-cluster`, but hosts [Akka.NET](https://getakka.net/) inside an ASP.NET Core 3.0 simple web application. |
+
 
 You can read more about how these templates work by clicking on their titles and reading the `README.md` for each individual project.
 
@@ -106,4 +109,4 @@ We accept pull requests! Please let us know what we can do to make these templat
 Petabridge provides [Akka.NET](http://getakka.net/) consulting, training, and support including advanced training in [Akka.Remote](https://petabridge.com/training/akka-remoting/), [Akka.Cluster](https://petabridge.com/training/akka-clustering/), and [Akka.NET Design Patterns](https://petabridge.com/training/akka-design-patterns/)!
 
 ---
-Copyright 2015 - 2018 Petabridge® All rights reserved.
+Copyright 2015 - 2019 Petabridge® All rights reserved.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,9 @@
-#### 1.0.1 October 05 2019 ####
+#### 1.0.2 October 31 2019 ####
 
-This is a major release of Petabridge.Templates, which includes the following changes:
+This release fixes issues with [only one of the three templates in `Petabridge.Templates` being accessible during `dotnet new`](https://github.com/petabridge/petabridge-dotnet-new/issues/127).
 
-1. All templates now run on .NET Core 3.0;
-2. Introduced the new `Petabridge.App` template as part of this package, which includes the ability to automatically create an Akka.Cluster application running inside a .NET Core 3.0 console application. Also includes Docker build support out of the box.
-3. Introduced the new `Petabridge.App.Web` template as part of this package, which includes the ability to automatically create an Akka.Cluster application running inside an ASP.NET Core 3.0 web application. Also includes Docker build support out of the box.
+You can now use the following three templates:
 
-Includes fixes for missing templates in v1.0.0.
+* `dotnet new pb-lib` - creates a .NET Standard 2.0 library with a corresponding unit test project, documentation, and build system.
+* `dotnet new pb-akka-cluster` - creates a headless .NET Core 3.0 service that includes full [Akka.NET](https://getakka.net/) clustering support, Docker support, documentation, and build systems.
+* `dotnet new pb-akka-web` - does the same as `pb-akka-cluster`, but hosts [Akka.NET](https://getakka.net/) inside an ASP.NET Core 3.0 simple web application.

--- a/src/Petabridge.Templates.csproj
+++ b/src/Petabridge.Templates.csproj
@@ -1,23 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.0</PackageVersion>
+    <PackageVersion>1.0.2</PackageVersion>
     <PackageId>Petabridge.Templates</PackageId>
     <Title>Petabridge.Templates</Title>
     <Authors>Petabridge</Authors>
     <Description>Professional .NET Core templates complete with CI, Docs, and more. Supports library, Akka.NET, and ASP.NET Core application types.</Description>
     <PackageTags>dotnet-new;templates;petabridge;akka;</PackageTags>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageReleaseNotes></PackageReleaseNotes>
+    <PackageReleaseNotes>This release fixes issues with [only one of the three templates in `Petabridge.Templates` being accessible during `dotnet new`](https://github.com/petabridge/petabridge-dotnet-new/issues/127).
+You can now use the following three templates:
+`dotnet new pb-lib` - creates a .NET Standard 2.0 library with a corresponding unit test project, documentation, and build system.
+`dotnet new pb-akka-cluster` - creates a headless .NET Core 3.0 service that includes full [Akka.NET](https://getakka.net/) clustering support, Docker support, documentation, and build systems.
+`dotnet new pb-akka-web` - does the same as `pb-akka-cluster`, but hosts [Akka.NET](https://getakka.net/) inside an ASP.NET Core 3.0 simple web application.</PackageReleaseNotes>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>
   </PropertyGroup>
-
   <ItemGroup>
     <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**" />
     <Compile Remove="**\*" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
#### 1.0.2 October 31 2019 ####

This release fixes issues with [only one of the three templates in `Petabridge.Templates` being accessible during `dotnet new`](https://github.com/petabridge/petabridge-dotnet-new/issues/127).

You can now use the following three templates:

* `dotnet new pb-lib` - creates a .NET Standard 2.0 library with a corresponding unit test project, documentation, and build system.
* `dotnet new pb-akka-cluster` - creates a headless .NET Core 3.0 service that includes full [Akka.NET](https://getakka.net/) clustering support, Docker support, documentation, and build systems.
* `dotnet new pb-akka-web` - does the same as `pb-akka-cluster`, but hosts [Akka.NET](https://getakka.net/) inside an ASP.NET Core 3.0 simple web application.
