### PR TITLE
v1.1.0 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,6 @@
-#### 1.0.5 January 30 2020 ####
+#### 1.1.0 March 02 2020 ####
 
-- Upgraded dependencies of all templates
-- Added SourceLink and NuGet symbol package support to `pb-lib`
+- Upgraded dependencies of all templates;
+- Upgraded all templates to .NET Core 3.1;
+- Added NBench 2.0 support to `pb-lib` template;
+- Updated README documentation to accurately reflect latest content of all templates.

--- a/src/Petabridge.Templates.csproj
+++ b/src/Petabridge.Templates.csproj
@@ -1,18 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.0.3</PackageVersion>
+    <PackageVersion>1.1.0</PackageVersion>
     <PackageId>Petabridge.Templates</PackageId>
     <Title>Petabridge.Templates</Title>
     <Authors>Petabridge</Authors>
     <Description>Professional .NET Core templates complete with CI, Docs, and more. Supports library, Akka.NET, and ASP.NET Core application types.</Description>
     <PackageTags>dotnet-new;templates;petabridge;akka;</PackageTags>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageReleaseNotes>Second and final attempt at fixing issue: [only one of the three templates in `Petabridge.Templates` being accessible during `dotnet new`](https://github.com/petabridge/petabridge-dotnet-new/issues/127).
-You can now use the following three templates:
-`dotnet new pb-lib` - creates a .NET Standard 2.0 library with a corresponding unit test project, documentation, and build system.
-`dotnet new pb-akka-cluster` - creates a headless .NET Core 3.0 service that includes full [Akka.NET](https://getakka.net/) clustering support, Docker support, documentation, and build systems.
-`dotnet new pb-akka-web` - does the same as `pb-akka-cluster`, but hosts [Akka.NET](https://getakka.net/) inside an ASP.NET Core 3.0 simple web application.</PackageReleaseNotes>
+    <PackageReleaseNotes>- Upgraded dependencies of all templates;
+- Upgraded all templates to .NET Core 3.1;
+- Added NBench 2.0 support to `pb-lib` template;
+- Updated README documentation to accurately reflect latest content of all templates.</PackageReleaseNotes>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>


### PR DESCRIPTION
#### 1.1.0 March 02 2020 ####

- Upgraded dependencies of all templates;
- Upgraded all templates to .NET Core 3.1;
- Added NBench 2.0 support to `pb-lib` template;
- Updated README documentation to accurately reflect latest content of all templates.