### PR TITLE
Release 2.0.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,9 @@
-#### 2.0.3 March 8 2022 ####
+#### 2.0.3 March 17 2022 ####
 
 - Added `.gitattributes` to prevent line endings from being modified upon checkout
 - Updated `pr_validation` to run `All` and not `RunTests`
 - Added steps to convert `build.cmd` and `build.sh` to executables - a fix for file permission issue.
+- Added `GitHubRelease` for publishing release on GitHub.
 
 #### 2.0.2 March 7 2022 ####
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 2.0.3 March 8 2022 ####
+
+- Added `.gitattributes` to prevent line endings from being modified upon checkout
+- Updated `pr_validation` to run `All` and not `RunTests`
+- Added steps to convert `build.cmd` and `build.sh` to executables - a fix for file permission issue.
+
 #### 2.0.2 March 7 2022 ####
 
 - Removed `GitVersion` from each of the `templates`

--- a/src/Petabridge.Templates.csproj
+++ b/src/Petabridge.Templates.csproj
@@ -2,14 +2,16 @@
   <PropertyGroup>
     <PackageType>Template</PackageType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageVersion>2.0.1</PackageVersion>
+    <PackageVersion>2.0.3</PackageVersion>
     <PackageId>Petabridge.Templates</PackageId>
     <Title>Petabridge.Templates</Title>
     <Authors>Petabridge</Authors>
     <Description>Professional .NET Core templates complete with CI, Docs, and more. Supports library, Akka.NET, and ASP.NET Core application types.</Description>
     <PackageTags>dotnet-new;templates;petabridge;akka;</PackageTags>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageReleaseNotes>- Fix missing `.gitignore` file - set `NoDefaultExcludes` to `true`.</PackageReleaseNotes>
+    <PackageReleaseNotes>- Added `.gitattributes` to prevent line endings from being modified upon checkout
+- Updated `pr_validation` to run `All` and not `RunTests`
+- Added steps to convert `build.cmd` and `build.sh` to executables - a fix for file permission issue.</PackageReleaseNotes>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>


### PR DESCRIPTION
## Changes

- Added `.gitattributes` to prevent line endings from being modified upon checkout
- Updated `pr_validation` to run `All` and not `RunTests`
- Added steps to convert `build.cmd` and `build.sh` to executables - a fix for file permission issue.

This worked first time in GitHub Action for `Windows, Ubuntu and MacOs`:

## Petabridge.App.Web

![image](https://user-images.githubusercontent.com/8049896/157287997-d1872924-3bb9-4724-a575-6916f946f130.png)
![image](https://user-images.githubusercontent.com/8049896/157288064-bc1cbd12-b36a-4dca-9de4-cf2f174e2e62.png)

## Petabridge.App

![image](https://user-images.githubusercontent.com/8049896/157288869-eb23a345-8c08-440c-b307-61ef7199b9b9.png)
![image](https://user-images.githubusercontent.com/8049896/157288944-c63091ea-2ec7-4250-a320-ea9b64134b6b.png)

## Petabridge.Library

![image](https://user-images.githubusercontent.com/8049896/157289037-d273713a-acd4-46f8-bfdd-a2b52a983ab8.png)
![image](https://user-images.githubusercontent.com/8049896/157289259-97e62669-a271-40ad-9801-65ada35c9c62.png)
